### PR TITLE
[Feat] #6 BuddyConTheme에 Color 색상 정의

### DIFF
--- a/core/designsystem/src/main/java/com/yapp/buddycon/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/yapp/buddycon/designsystem/theme/Color.kt
@@ -1,13 +1,259 @@
 package com.yapp.buddycon.designsystem.theme
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class BuddyConColors(
+    val primary: Color
+)
+
+val LocalBuddyConColors = staticCompositionLocalOf {
+    BuddyConColors(
+        primary = Color.Unspecified
+    )
+}
 
 val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
 val Purple40 = Color(0xFF6650a4)
+
+val PurpleGrey80 = Color(0xFFCCC2DC)
 val PurpleGrey40 = Color(0xFF625b71)
+
+val Pink100 = Color(0xFFFF4E6E)
+val Pink80 = Color(0xFFEFB8C8)
+val Pink50 = Color(0xFFFFEDF0)
 val Pink40 = Color(0xFF7D5260)
+val Pink20 = Color(0xFFFFF6F8)
 
 val Grey90 = Color(0xFF2D2D2D)
+val Grey70 = Color(0xFF6F6F71)
+val Grey60 = Color(0xFF838486)
+val Grey50 = Color(0xFFAEAFB1)
+val Grey40 = Color(0xFFCBCCCE)
+val Grey30 = Color(0xFFECEDEF)
+val Grey20 = Color(0xFFF2F3F5)
+
+val Black = Color(0xFF000000)
+
+val White = Color(0xFFFFFFFF)
+
+@Preview(widthDp = 540)
+@Composable
+private fun ColorPreview() {
+    BuddyConTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(White)
+        ) {
+            Row {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(BuddyConTheme.colors.primary)
+                    )
+                    Text(
+                        text = "Pink100",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Pink50)
+                    )
+                    Text(
+                        text = "Pink50",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Pink20)
+                    )
+                    Text(
+                        text = "Pink20",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+            }
+            Row(modifier = Modifier.padding(top = 20.dp)) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Black)
+                    )
+                    Text(
+                        text = "Black",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Grey90)
+                    )
+                    Text(
+                        text = "Grey90",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Grey70)
+                    )
+                    Text(
+                        text = "Grey70",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Grey60)
+                    )
+                    Text(
+                        text = "Grey60",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Grey50)
+                    )
+                    Text(
+                        text = "Grey50",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+            }
+            Row(modifier = Modifier.padding(top = 20.dp)) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Grey40)
+                    )
+                    Text(
+                        text = "Grey40",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Grey30)
+                    )
+                    Text(
+                        text = "Grey30",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .clip(CircleShape)
+                            .background(Grey20)
+                    )
+                    Text(
+                        text = "Grey20",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+                Column(
+                    modifier = Modifier.padding(start = 30.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(
+                        modifier = Modifier
+                            .size(80.dp)
+                            .border(2.dp, Grey60, CircleShape)
+                            .clip(CircleShape)
+                            .background(White)
+                    )
+                    Text(
+                        text = "White",
+                        modifier = Modifier.padding(top = 5.dp),
+                        color = Grey90
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/yapp/buddycon/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/yapp/buddycon/designsystem/theme/Theme.kt
@@ -29,16 +29,6 @@ private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
     tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
 )
 
 @Composable
@@ -165,7 +155,14 @@ fun BuddyConTheme(
         )
     )
 
-    CompositionLocalProvider(LocalBuddyConTypography provides buddyConTypography) {
+    val buddyConColors = BuddyConColors(
+        primary = Pink100
+    )
+
+    CompositionLocalProvider(
+        LocalBuddyConTypography provides buddyConTypography,
+        LocalBuddyConColors provides buddyConColors
+    ) {
         MaterialTheme(
             colorScheme = colorScheme,
             content = content
@@ -177,4 +174,8 @@ object BuddyConTheme {
     val typography: BuddyConTypography
         @Composable
         get() = LocalBuddyConTypography.current
+
+    val colors: BuddyConColors
+        @Composable
+        get() = LocalBuddyConColors.current
 }


### PR DESCRIPTION
## 구체적인 작업 내용
- [x] BuddyCon 개발에 필요한 색상 정의
- [x] 색상 preview 구현

## 화면 ( option - UI 관련 작업시에만 )
<img width="496" alt="image" src="https://github.com/Team-BuddyCon/ANDROID_V2/assets/34837583/3cb1a4bb-6542-48f3-93c7-23bfe770002e">

## Close Issue
Close #6 