### PR TITLE
기프티콘 카테고리 별 사용 가능 기프티콘 및 유효기간 임박 표시

### DIFF
--- a/core/designsystem/src/main/java/com/yapp/buddycon/designsystem/component/appbar/BaseAppBar.kt
+++ b/core/designsystem/src/main/java/com/yapp/buddycon/designsystem/component/appbar/BaseAppBar.kt
@@ -96,7 +96,7 @@ internal fun BaseAppBar(buddyConAppBars: BuddyConAppBars) {
                 when (buddyConAppBars) {
                     is BuddyConAppBars.WithNotification -> {
                         Icon(
-                            painter = painterResource(R.drawable.ic_notification_sel),
+                            painter = painterResource(R.drawable.ic_notification),
                             contentDescription = buddyConAppBars.title,
                             modifier = Modifier
                                 .size(AppbarIconSize)

--- a/core/network/src/main/java/com/yapp/buddycon/network/service/gifticon/GiftiConService.kt
+++ b/core/network/src/main/java/com/yapp/buddycon/network/service/gifticon/GiftiConService.kt
@@ -48,7 +48,10 @@ interface GiftiConService {
 
     @GET("api/v1/gifticons/count")
     suspend fun getGifticonCount(
-        @Query("used") used: Boolean
+        @Query("used") used: Boolean,
+        @Query("gifticonStoreCategory") gifticonStoreCategory: String? = null,
+        @Query("gifticonStore") gifticonStore: String? = null,
+        @Query("remainingDays") remainingDays: Int? = null
     ): GifticonCountResponse
 
     /** 기프티콘 상세 정보 수정 */

--- a/data/src/main/java/com/yapp/buddycon/data/repository/remote/GifticonRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/buddycon/data/repository/remote/GifticonRepositoryImpl.kt
@@ -103,11 +103,19 @@ class GifticonRepositoryImpl @Inject constructor(
         ).flow
     }
 
-    override fun getGifticonCount(used: Boolean): Flow<Int> = flow {
+    override fun getGifticonCount(
+        used: Boolean,
+        gifticonStoreCategory: GifticonStoreCategory?,
+        gifticonStore: GifticonStore?,
+        remainingDays: Int?
+    ): Flow<Int> = flow {
         emit(
-            giftiConService.getGifticonCount(used)
-                .body
-                .count
+            giftiConService.getGifticonCount(
+                used = used,
+                gifticonStoreCategory = gifticonStoreCategory?.name,
+                gifticonStore = gifticonStore?.code,
+                remainingDays = remainingDays
+            ).body.count
         )
     }
 

--- a/domain/src/main/java/com/yapp/buddycon/domain/model/type/GifticonStore.kt
+++ b/domain/src/main/java/com/yapp/buddycon/domain/model/type/GifticonStore.kt
@@ -12,7 +12,7 @@ enum class GifticonStore(val value: String, val code: String?) {
     MACDONALD("맥도날드", "MACDONALD"),
     GS25("GS25", "GS25"),
     CU("CU", "CU"),
-    OTHERS("기타", "OTHERS'"),
+    OTHERS("기타", "OTHERS"),
     NONE("", "")
 }
 

--- a/domain/src/main/java/com/yapp/buddycon/domain/repository/GifticonRepository.kt
+++ b/domain/src/main/java/com/yapp/buddycon/domain/repository/GifticonRepository.kt
@@ -31,7 +31,10 @@ interface GifticonRepository {
     fun fetchUnavailableGifticon(): Flow<PagingData<UnavailableGifticon.UnavailableGifticonInfo>>
 
     fun getGifticonCount(
-        used: Boolean
+        used: Boolean,
+        gifticonStoreCategory: GifticonStoreCategory? = null,
+        gifticonStore: GifticonStore? = null,
+        remainingDays: Int? = null
     ): Flow<Int>
 
     fun editGifticonDetail(

--- a/feature/gifticon/build.gradle
+++ b/feature/gifticon/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation project(":core:utility")
 
     implementation libs.hilt.android
+    implementation libs.androidx.constraintlayout
     kapt libs.hilt.compiler
     implementation libs.accompanist.systemuicontroller
 

--- a/feature/map/src/main/java/com/yapp/buddycon/map/MapViewModel.kt
+++ b/feature/map/src/main/java/com/yapp/buddycon/map/MapViewModel.kt
@@ -45,6 +45,7 @@ class MapViewModel @Inject constructor(
 
     init {
         getGifticonCount()
+        getDeadLineCount()
     }
 
     fun fetchAvailableGifticon() {
@@ -58,12 +59,26 @@ class MapViewModel @Inject constructor(
     }
 
     private fun getGifticonCount() {
-        gifticonRepository.getGifticonCount(used = false)
-            .onEach {
-                _mapUiState.value = _mapUiState.value.copy(
-                    totalCount = it
-                )
-            }.launchIn(viewModelScope)
+        gifticonRepository.getGifticonCount(
+            used = false,
+            gifticonStore = mapUiState.value.store
+        ).onEach {
+            _mapUiState.value = _mapUiState.value.copy(
+                totalCount = it
+            )
+        }.launchIn(viewModelScope)
+    }
+
+    private fun getDeadLineCount() {
+        gifticonRepository.getGifticonCount(
+            used = false,
+            gifticonStore = mapUiState.value.store,
+            remainingDays = 14
+        ).onEach {
+            _mapUiState.value = _mapUiState.value.copy(
+                deadLineCount = it
+            )
+        }.launchIn(viewModelScope)
     }
 
     fun searchPlacesByKeyword(
@@ -97,6 +112,8 @@ class MapViewModel @Inject constructor(
             store = store
         )
         fetchAvailableGifticon()
+        getGifticonCount()
+        getDeadLineCount()
     }
 
     fun changeBottomSheetValue(sheetValue: BottomSheetValue) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -135,6 +135,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version = "2.1.4" }
 
 [bundles]
 androidx-compose = ["androidx-compose-ui", "androidx-compose-ui-tooling", "androidx-compose-ui-tooling-preview", "androidx-activity-compose", "androidx-compose-material3", "androidx-navigation-compose", "androidx-lifecycle-compose", "androidx-hilt-navigation-compose"]


### PR DESCRIPTION
## 구체적인 작업 내용
- [x] 기프티콘 카테고리 별 사용 가능 기프티콘 및 유효기간 임박 표시
- [x] 기프티콘 상세에서 위치 권한 없을 때 기타 쿠폰의 스낵바 메세지 수정
- [x] 상단 앱자 노출되는 기본 알림 아이콘 수정  

## Close Issue
Close #72 